### PR TITLE
Fixed the text overlapping issue in HTML to PDF conversion 

### DIFF
--- a/qtbase/src/gui/painting/qpdf.cpp
+++ b/qtbase/src/gui/painting/qpdf.cpp
@@ -2693,10 +2693,6 @@ void QPdfEnginePrivate::drawTextItem(const QPointF &p, const QTextItemInt &ti)
 
     qreal size = ti.fontEngine->fontDef.pixelSize;
 
-#if defined(Q_OS_WIN)
-   size = (ti.fontEngine->ascent() + ti.fontEngine->descent()).toReal();
-#endif
-
     QVarLengthArray<glyph_t> glyphs;
     QVarLengthArray<QFixedPoint> positions;
     QTransform m = QTransform::fromTranslate(p.x(), p.y());

--- a/qtwebkit/Source/WebCore/page/PrintContext.cpp
+++ b/qtwebkit/Source/WebCore/page/PrintContext.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 // print in IE and Camino. This lets them use fewer sheets than they
 // would otherwise, which is presumably why other browsers do this.
 // Wide pages will be scaled down more than this.
-const float printingMinimumShrinkFactor = 1.25f;
+const float printingMinimumShrinkFactor = 1.0f;
 
 // This number determines how small we are willing to reduce the page content
 // in order to accommodate the widest line. If the page would have to be

--- a/qtwebkit/Source/WebKit/qt/WebCoreSupport/QWebFrameAdapter.cpp
+++ b/qtwebkit/Source/WebKit/qt/WebCoreSupport/QWebFrameAdapter.cpp
@@ -328,7 +328,7 @@ QSize QWebFrameAdapter::contentsSize() const
 
 void QWebFrameAdapter::setZoomFactor(qreal factor)
 {
-    if (pageAdapter->settings->testAttribute(QWebSettings::ZoomTextOnly))
+    if (!(pageAdapter->settings->testAttribute(QWebSettings::ZoomTextOnly)))
         frame->setTextZoomFactor(factor);
     else
         frame->setPageZoomFactor(factor);


### PR DESCRIPTION
Using font size instead of getting ascend and descend value. And reducing the minimum shrinking factor we got better output. Set the zoom Factor to text instead of page to avoid unwanted spaces between words.