### PR TITLE
Fixed viewport width issue in HTML to PDF conversion.

### DIFF
--- a/qtwebkit/Source/WebCore/page/PrintContext.cpp
+++ b/qtwebkit/Source/WebCore/page/PrintContext.cpp
@@ -160,11 +160,18 @@ void PrintContext::computePageRectsWithPageSizeInternal(const FloatSize& pageSiz
     }
 }
 
+QSize viewportToPdf;
+
+void PrintContext::setViewportToPdf(QSize size){
+	viewportToPdf = size;
+}
+
 IntRect PrintContext::begin(float width, float height)
 {
     // This function can be called multiple times to adjust printing parameters without going back to screen mode.
     m_isPrinting = true;
 
+	width = (float)viewportToPdf.width();
     FloatSize originalPageSize = FloatSize(width, height);
     FloatSize minLayoutSize = m_frame->resizePageRectsKeepingRatio(originalPageSize, FloatSize(width * printingMinimumShrinkFactor, height * printingMinimumShrinkFactor));
 

--- a/qtwebkit/Source/WebCore/page/PrintContext.h
+++ b/qtwebkit/Source/WebCore/page/PrintContext.h
@@ -23,6 +23,7 @@
 
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
+#include <qsize.h>
 
 namespace WebCore {
 
@@ -56,6 +57,7 @@ public:
 
     float computeAutomaticScaleFactor(const FloatSize& availablePaperSize);
 
+	void setViewportToPdf(QSize);
     // Enter print mode, updating layout for new page size.
     // This function can be called multiple times to apply new print options without going back to screen mode.
     IntRect begin(float width, float height = 0);

--- a/qtwebkit/Source/WebKit/qt/WebCoreSupport/QWebFrameAdapter.cpp
+++ b/qtwebkit/Source/WebKit/qt/WebCoreSupport/QWebFrameAdapter.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "QWebFrameAdapter.h"
 
+#include "PrintContext.h"
 #include "APICast.h"
 #include "Chrome.h"
 #include "ChromeClientQt.h"
@@ -975,6 +976,8 @@ void QWebFrameAdapter::setViewportSize(const QSize& size)
     ASSERT(view);
     view->resize(size);
     view->adjustViewSize();
+	PrintContext printer(frame);
+	printer.setViewportToPdf(size);
 
     if (view->needsLayout())
         view->layout();


### PR DESCRIPTION
Viewport width not preserved in output  while converting html to pdf. Now added the viewport width to calculate page rect.